### PR TITLE
Enable esbuild bundle minification.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "typescript-coverage-report": "^0.5.1"
   },
   "scripts": {
-    "compile": "./node_modules/.bin/tsc -p tsconfig.json",
-    "compile-watch": "./node_modules/.bin/tsc -p tsconfig.json --watch",
+    "compile": "tsc -p tsconfig.json",
+    "compile-watch": "tsc -p tsconfig.json --watch",
     "lint": "eslint . --ext .ts",
     "lint-watch": "npm-watch lint",
-    "bundle": "./node_modules/.bin/esbuild --bundle --sourcemap --loader:.html=text  --loader:.css=text --loader:.icon.svg=text --loader:.svg=dataurl simulator/src/LogicEditor.ts --outfile=simulator/lib/bundle.js && tools/insert_md5_into_index.sh",
+    "bundle": "esbuild --minify --bundle --sourcemap --loader:.html=text  --loader:.css=text --loader:.icon.svg=text --loader:.svg=dataurl simulator/src/LogicEditor.ts --outfile=simulator/lib/bundle.js && tools/insert_md5_into_index.sh",
     "bundle-watch": "npm-watch bundle",
     "server": "./tools/local_server.py 8088",
     "deploy-all": "./deploy-jpp.sh && ./deploy-modulo.sh && ./deploy-modulo-dev.sh",


### PR DESCRIPTION
Hi, thanks for this great tool that I just discovered!

Just a simple suggestion to minify the bundle. My tests show that it saves about 46% of the bandwidth (24% with gzip compression). It seems to not break the source mapping.

I also removed all the `./node_modules/.bin/` stuff since `npm` is smart enough to look into this directory even if it is not in the `PATH`.

Romain