### PR TITLE
Fixing some errors when compiling a fresh clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 node_modules
 /simulator/js
+/simulator/lib
 /index.html
 /deploy-*.sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "canvas2svg": "^1.0.16",
         "dialog-polyfill": "^0.5.6",
         "electron": "^21.1.1",
-        "fp-ts": "^2.9.5",
+        "fp-ts": "^2.13.1",
         "io-ts": "^2.2.16",
         "lz-string": "^1.4.4",
         "png-metadata-writer": "^1.0.1",
@@ -2139,9 +2139,9 @@
       "dev": true
     },
     "node_modules/fp-ts": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.9.5.tgz",
-      "integrity": "sha512-MiHrA5teO6t8zKArE3DdMPT/Db6v2GUt5yfWnhBTrrsVfeCJUUnV6sgFvjGNBKDmEMqVwRFkEePL7wPwqrLKKA=="
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.13.1.tgz",
+      "integrity": "sha512-0eu5ULPS2c/jsa1lGFneEFFEdTbembJv8e4QKXeVJ3lm/5hyve06dlKZrpxmMwJt6rYen7sxmHHK2CLaXvWuWQ=="
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
@@ -6174,9 +6174,9 @@
       "dev": true
     },
     "fp-ts": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.9.5.tgz",
-      "integrity": "sha512-MiHrA5teO6t8zKArE3DdMPT/Db6v2GUt5yfWnhBTrrsVfeCJUUnV6sgFvjGNBKDmEMqVwRFkEePL7wPwqrLKKA=="
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.13.1.tgz",
+      "integrity": "sha512-0eu5ULPS2c/jsa1lGFneEFFEdTbembJv8e4QKXeVJ3lm/5hyve06dlKZrpxmMwJt6rYen7sxmHHK2CLaXvWuWQ=="
     },
     "fs-extra": {
       "version": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "canvas2svg": "^1.0.16",
     "dialog-polyfill": "^0.5.6",
     "electron": "^21.1.1",
-    "fp-ts": "^2.9.5",
+    "fp-ts": "^2.13.1",
     "io-ts": "^2.2.16",
     "lz-string": "^1.4.4",
     "png-metadata-writer": "^1.0.1",

--- a/simulator/src/B64.ts
+++ b/simulator/src/B64.ts
@@ -14,7 +14,7 @@ export const B64 = {
         let position = -1,
             nan0, nan1, nan2
         if (B64.ie) {
-            const result = []
+            const result: Array<string> = []
             while (++position < len) {
                 nan0 = buffer[position]
                 nan1 = buffer[++position]
@@ -54,7 +54,7 @@ export const B64 = {
         const len = buffer.length
         let position = 0
         if (B64.ieo) {
-            const result = []
+            const result: Array<string> = []
             while (position < len) {
                 if (buffer[position] < 128) { result.push(String.fromCharCode(buffer[position++])) }
                 else if (buffer[position] > 191 && buffer[position] < 224) { result.push(String.fromCharCode(((buffer[position++] & 31) << 6) | (buffer[position++] & 63))) }
@@ -74,7 +74,7 @@ export const B64 = {
 
     toUtf8: function (s: string) {
         const len = s.length
-        const buffer = []
+        const buffer: Array<number> = []
         let position = -1
         // eslint-disable-next-line no-control-regex
         if (/^[\x00-\x7f]*$/.test(s)) {
@@ -93,7 +93,7 @@ export const B64 = {
     fromUtf8: function (s: string) {
         let position = -1
         let len
-        const buffer = []
+        const buffer: Array<number> = []
         const enc = [NaN, NaN, NaN, NaN]
 
         if (B64.lookup === null) {

--- a/simulator/src/components/Wire.ts
+++ b/simulator/src/components/Wire.ts
@@ -794,7 +794,7 @@ export class WireManager {
     }
 
     addNode(newNode: Node): Wire | undefined {
-        let completedWire = undefined
+        let completedWire: Wire | undefined = undefined
         if (!this.isAddingWire) {
             // start drawing a new wire
             const wire = new Wire(newNode)


### PR DESCRIPTION
Today I cloned and compiled the project for the first time and got some errors from TypeScript when compiling (maybe due to a more recent version of TypeScript?). I did the following to fix the errors:

- add explicit types to some arrays in `B64.ts` and `wire.ts`;
- update the `fp-ts` dependency to a more recent version.

I also added `/simulator/lib` to `.gitignore` as it does not exist in the repository but TypeScript compiles to this directory.

Let me know if I should change anything!