### PR TITLE
superfence for mkdocs

### DIFF
--- a/simulator/src/LogicEditor.ts
+++ b/simulator/src/LogicEditor.ts
@@ -61,6 +61,7 @@ const ATTRIBUTE_NAMES = {
     singleton: "singleton", // whether this is the only editor in the page
     mode: "mode",
     hidereset: "hidereset",
+    superfence: "superfence", //for pymdownx.superfences with mkdocs
 
     // these are mirrored in the display options
     name: "name",
@@ -173,7 +174,8 @@ export class LogicEditor extends HTMLElement implements DrawableParent {
     private _initialData: InitialData | undefined = undefined
     private _options: EditorOptions = { ...DEFAULT_EDITOR_OPTIONS }
     private _hideResetButton = false
-
+    private _isSuperFence = false
+    
     private _menu: ComponentMenu | undefined = undefined
     private _topBar: TopBar | undefined = undefined
     private _messageBar: MessageBar | undefined = undefined
@@ -440,6 +442,7 @@ export class LogicEditor extends HTMLElement implements DrawableParent {
         const singletonAttr = this.getAttribute(ATTRIBUTE_NAMES.singleton)
         this._isSingleton = !this._isEmbedded && singletonAttr !== null && !isFalsyString(singletonAttr)
         this._maxInstanceMode = this._isSingleton && !this._isEmbedded ? MAX_MODE_WHEN_SINGLETON : MAX_MODE_WHEN_EMBEDDED
+        this._isSuperFence = isTruthyString(this.getAttribute(ATTRIBUTE_NAMES.superfence))
 
         // Transfer from URL param to attributes if we are in singleton mode
         if (this._isSingleton || this._isEmbedded) {
@@ -1415,8 +1418,13 @@ export class LogicEditor extends HTMLElement implements DrawableParent {
         const modeParam = mode === MAX_MODE_WHEN_EMBEDDED ? "" : `:mode: ${modeStr}\n`
         const embedHeight = this.guessAdequateCanvasSize(true)[1]
 
-        const markdownBlock = `\`\`\`{logic}\n:height: ${embedHeight}\n${modeParam}\n${fullJson}\n\`\`\``
-        this.html.embedMarkdown.value = markdownBlock
+        if (this._isSuperFence) {
+            const markdownBlock = `\`\`\`{.logic height=${embedHeight} mode=${modeStr}}\n${fullJson}\n\`\`\``
+            this.html.embedMarkdown.value = markdownBlock
+        } else {
+            const markdownBlock = `\`\`\`{logic}\n:height: ${embedHeight}\n${modeParam}\n${fullJson}\n\`\`\``
+            this.html.embedMarkdown.value = markdownBlock
+        }
 
         const iframeEmbed = `<iframe style="width: 100%; height: ${embedHeight}px; border: 0" src="${fullUrl}"></iframe>`
         this.html.embedIframe.value = iframeEmbed

--- a/simulator/src/LogicEditor.ts
+++ b/simulator/src/LogicEditor.ts
@@ -55,13 +55,14 @@ enum Mode {
 const MAX_MODE_WHEN_SINGLETON = Mode.FULL
 const MAX_MODE_WHEN_EMBEDDED = Mode.DESIGN
 const DEFAULT_MODE = Mode.DESIGN
+const DEFAULT_EXPORT_FORMAT= "myst"
 
 const ATTRIBUTE_NAMES = {
     lang: "lang",
     singleton: "singleton", // whether this is the only editor in the page
     mode: "mode",
     hidereset: "hidereset",
-    superfence: "superfence", //for pymdownx.superfences with mkdocs
+    exportformat: "exportformat", // differences between MyST and pymarkdown
 
     // these are mirrored in the display options
     name: "name",
@@ -174,7 +175,7 @@ export class LogicEditor extends HTMLElement implements DrawableParent {
     private _initialData: InitialData | undefined = undefined
     private _options: EditorOptions = { ...DEFAULT_EDITOR_OPTIONS }
     private _hideResetButton = false
-    private _isSuperFence = false
+    private _exportformat = DEFAULT_EXPORT_FORMAT
     
     private _menu: ComponentMenu | undefined = undefined
     private _topBar: TopBar | undefined = undefined
@@ -442,7 +443,7 @@ export class LogicEditor extends HTMLElement implements DrawableParent {
         const singletonAttr = this.getAttribute(ATTRIBUTE_NAMES.singleton)
         this._isSingleton = !this._isEmbedded && singletonAttr !== null && !isFalsyString(singletonAttr)
         this._maxInstanceMode = this._isSingleton && !this._isEmbedded ? MAX_MODE_WHEN_SINGLETON : MAX_MODE_WHEN_EMBEDDED
-        this._isSuperFence = isTruthyString(this.getAttribute(ATTRIBUTE_NAMES.superfence))
+        this._exportformat = this.getAttribute(ATTRIBUTE_NAMES.exportformat)
 
         // Transfer from URL param to attributes if we are in singleton mode
         if (this._isSingleton || this._isEmbedded) {
@@ -1418,10 +1419,10 @@ export class LogicEditor extends HTMLElement implements DrawableParent {
         const modeParam = mode === MAX_MODE_WHEN_EMBEDDED ? "" : `:mode: ${modeStr}\n`
         const embedHeight = this.guessAdequateCanvasSize(true)[1]
 
-        if (this._isSuperFence) {
+        if (this._exportformat == "superfence") {
             const markdownBlock = `\`\`\`{.logic height=${embedHeight} mode=${modeStr}}\n${fullJson}\n\`\`\``
             this.html.embedMarkdown.value = markdownBlock
-        } else {
+        } else if (this._exportformat == "myst") {
             const markdownBlock = `\`\`\`{logic}\n:height: ${embedHeight}\n${modeParam}\n${fullJson}\n\`\`\``
             this.html.embedMarkdown.value = markdownBlock
         }


### PR DESCRIPTION
Hi,
Finally I did implement a `superfence` attribute  to adapt the `markdownBlock` to be used with [pymdownx.superfences](https://facelessuser.github.io/pymdown-extensions/extensions/superfences/) with [mkdocs](https://www.mkdocs.org/) and the [custom fence](https://mkdocs-logic.forge.apps.education.fr/) I've developped.

Do you think that it could be merge ?
This way, I can modify my custom fence to rebuild the bundle when you make changes ?

Thanks again for your work !